### PR TITLE
routine vector can now start iterating at a non-zero starting point

### DIFF
--- a/src/routine/builder.rs
+++ b/src/routine/builder.rs
@@ -19,32 +19,42 @@ use crate::{
     routine::Routine,
 };
 
-pub struct RoutineBuilder<PSH>(Vec<Arc<Job<PSH>>>);
+pub struct RoutineBuilder<PSH> {
+    jobs: Vec<Arc<Job<PSH>>>,
+    start_index: usize,
+}
 
 impl<PSH> RoutineBuilder<PSH> {
-    pub fn new() -> Self { Self(Vec::new()) }
+    pub fn new() -> Self {
+        Self {
+            jobs: Vec::new(),
+            start_index: 0usize,
+        }
+    }
 
-    pub fn push(&mut self, job: Job<PSH>) { self.0.push(Arc::new(job)) }
+    pub fn push(&mut self, job: Job<PSH>) { self.jobs.push(Arc::new(job)) }
+
+    pub fn set_start_index(&mut self, start_index: usize) { self.start_index = start_index }
 }
 
 impl<PSH> Builder<Routine<PSH>, ()> for RoutineBuilder<PSH> {
-    fn build(self) -> Result<Routine<PSH>, ()> { Ok(Routine::new(self.0)) }
+    fn build(self) -> Result<Routine<PSH>, ()> { Ok(Routine::new(self.jobs, self.start_index)) }
 }
 
 impl<PSH> Deref for RoutineBuilder<PSH> {
     type Target = Vec<Arc<Job<PSH>>>;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target { &self.jobs }
 }
 
 impl<PSH> DerefMut for RoutineBuilder<PSH> {
-    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.jobs }
 }
 
 impl<PSH> AsRef<Vec<Arc<Job<PSH>>>> for RoutineBuilder<PSH> {
-    fn as_ref(&self) -> &Vec<Arc<Job<PSH>>> { &self.0 }
+    fn as_ref(&self) -> &Vec<Arc<Job<PSH>>> { &self.jobs }
 }
 
 impl<PSH> AsMut<Vec<Arc<Job<PSH>>>> for RoutineBuilder<PSH> {
-    fn as_mut(&mut self) -> &mut Vec<Arc<Job<PSH>>> { &mut self.0 }
+    fn as_mut(&mut self) -> &mut Vec<Arc<Job<PSH>>> { &mut self.jobs }
 }

--- a/src/routine/mod.rs
+++ b/src/routine/mod.rs
@@ -17,18 +17,16 @@ use crate::{
 
 pub struct Routine<PSH> {
     jobs: Box<[Arc<Job<PSH>>]>,
+    start_index: usize,
     current_index: usize,
-    max_capacity: usize,
 }
 
 impl<PSH> Routine<PSH> {
-    pub(crate) fn new(jobs: Vec<Arc<Job<PSH>>>) -> Self {
-        let max_capacity = jobs.len();
-
+    pub(crate) fn new(jobs: Vec<Arc<Job<PSH>>>, start_index: usize) -> Self {
         Self {
             jobs: jobs.into_boxed_slice(),
+            start_index,
             current_index: 0usize,
-            max_capacity,
         }
     }
 }
@@ -37,25 +35,15 @@ impl<PSH> Iterator for Routine<PSH> {
     type Item = Arc<Job<PSH>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.max_capacity == 0usize {
-            None
-        } else {
-            Some(
-                self.jobs
-                    .get(self.current_index)
-                    .unwrap() // unwrap should never fail
-                    .clone(),
-            )
-        }
-        .map(|item| {
-            self.current_index = if self.current_index == (self.max_capacity - 1usize) {
-                0usize
-            } else {
-                self.current_index + 1usize
-            };
+        match self.jobs.get(self.current_index) {
+            Some(job) => {
+                if self.current_index == (self.jobs.len() - 1usize) { self.current_index = self.start_index }
+                else { self.current_index += 1usize }
 
-            item
-        })
+                Some(job.clone())
+            },
+            None => None,
+        }
     }
 }
 


### PR DESCRIPTION
Edited the iterator implementation to simplify logic and allow for the start-index of iteration to be non-zero.

A non-zero start index (e.g., `start_index = n`) means that the first `n-1` jobs only get run once.

This means that routines can now contain `initialization jobs` and `repeated jobs` (i.e., the first `n-1` jobs are init-jobs and the rest of repeated job).

Init-jobs will only be run once during the component's lifetime. Good for executing functions that should only happen during initialization and should not be repeated.